### PR TITLE
chore: release v0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1](https://github.com/AllenDang/egui_zhcn_fonts/compare/v0.1.0...v0.1.1) - 2025-02-24
+
+### Other
+
+- release v0.1.0
+
 ## [0.1.0](https://github.com/AllenDang/egui_zhcn_fonts/releases/tag/v0.1.0) - 2025-02-24
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,7 +73,7 @@ dependencies = [
 
 [[package]]
 name = "egui_zhcn_fonts"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "egui",
  "findfont",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "egui_zhcn_fonts"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 description = "load system zhcn fonts automatically for egui"
 categories = ["gui"]


### PR DESCRIPTION



## 🤖 New release

* `egui_zhcn_fonts`: 0.1.0 -> 0.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.1](https://github.com/AllenDang/egui_zhcn_fonts/compare/v0.1.0...v0.1.1) - 2025-02-24

### Other

- release v0.1.0
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).